### PR TITLE
Add support for `hide_side_toolbar` setting

### DIFF
--- a/background.js
+++ b/background.js
@@ -6,7 +6,7 @@ const INITED = '✓';
 const NOTINITED = '×';
 const TRADING_VIEW_DEFAULT_OPTIONS = {
     width: '100%',
-    height: 400,
+    height: 550,
     interval: 30,
     timezone: 'America/New_York',
     theme: 'Light',

--- a/settings.css
+++ b/settings.css
@@ -12,7 +12,9 @@ button[data-enabled=false] .disabled { display:none; }
 button[data-enabled=true] + .sub-settings { display:block; }
 button[data-enabled=false] + .sub-settings { display:none; }
 input, select { padding: 3px 6px; width:100%; }
+input[type=checkbox] { display:inline-block; width:auto; }
 small { display:block; color: #999; text-align:center; width: 100%; }
 label { display:block; padding-top:3px; }
 button:focus, textarea:focus, input:focus{ outline: none; }
 .hide { display:none; }
+.padded { padding:5px 0px; }

--- a/settings.html
+++ b/settings.html
@@ -32,6 +32,12 @@ body { width:95%; height:100%; }
                 <label for="tvConfHeight">Height</label>
                 <input type="text" id="tvConfHeight" placeholder="height, e.g. 400"/>
             </div>
+            <div class="padded">
+                <label for="tvConfHide_side_toolbar">
+                    <input id="tvConfHide_side_toolbar" type="checkbox" value="false" />
+                    Show Toolbar &amp; Drawing Tools
+                </label>
+            </div>
             <div>
                 <label for="tvConfInterval">Interval</label>
                 <select id="tvConfInterval" placeholder="interval, e.g. 30m">


### PR DESCRIPTION
- If height < 550px, ensures height is appropriately set
- Shows setting as "show side toolbar", even though prop is inverse
- Special handling support for checkboxes (boolean properties)

Closes #12 