### PR TITLE
Support `USDT-*` markets

### DIFF
--- a/enhanced-styles.css
+++ b/enhanced-styles.css
@@ -2,3 +2,28 @@
 .table td {
 	border: 0px !important;
 }
+#pad-wrapper h4 { 
+    text-decoration: none !important; 
+    font-style: normal !important; 
+}
+* {
+    border-radius: 0px !important;
+}
+.table td.est-usd-price,
+.table td.est-btc-price,
+.table td.est-usd-value,
+.table td.mkt-hist-usd-price,
+.table td.mkt-hist-usd-total,
+.table td.est-price {
+    text-align:right;
+}
+#est-price-BTC,
+#est-price-ETH,
+#est-btc-price,
+#est-usd-value,
+#est-price-buy,
+#est-price-sell,
+#mkt-history-bid-usd-val,
+#mkt-history-total-usd-val { 
+    text-align:center; 
+}

--- a/enhancer.js
+++ b/enhancer.js
@@ -11,9 +11,14 @@ const CONSTANTS = {
   balanceTableDomID: 'balanceTable',
   tickerQueryParamName: 'MarketName',
   classes: {
+    estPrice: 'est-price',
     estUsdPrice: 'est-usd-price',
     estBtcPrice: 'est-btc-price',
-    estUsdValue: 'est-usd-value'
+    estUsdValue: 'est-usd-value',
+    mktHistoryBidAskUsdVal: 'mkt-history-bid-usd-val',
+    mktHistoryTotalUsdVal: 'mkt-history-total-usd-val',
+    mktHistoryUsdPrice: 'mkt-hist-usd-price',
+    mktHistoryUsdTotal: 'mkt-hist-usd-total'
   }
 };
 
@@ -23,7 +28,7 @@ Number.prototype.format = function(n, x) {
 };
 
 function getPriceFromNode(marketType, col){
-  let nodePrice = parseFloat(col.innerText); // col.childNodes.length > 0 ? col.childNodes[0].textContent : 
+  let nodePrice = parseFloat(col.innerText); 
   let isUsdtMarket = marketType === 'usdt';
   let currencySymbol = isUsdtMarket ? 'Ƀ' : '$';
   let formatDp = isUsdtMarket ? 8 : 2;
@@ -242,12 +247,12 @@ Enhancer.enhanceOrderTable = function enhanceOrderTable(type, table){
         updateHeader('est-price-' + type, row, priceColIdx, title + ' (Est. ' + (isUsdtMarket?'BTC':'USD') + ')');
         continue;
       }
-      let alreadyInserted = getChildNodeWithClass(row, "est-price");
+      let alreadyInserted = getChildNodeWithClass(row, CONSTANTS.classes.estPrice);
       let priceIdx = priceColIdx;
       if(alreadyInserted){
         priceIdx += type === 'buy' ? 1 : 1;
       }
-      updateColumn("est-price", row, priceIdx);
+      updateColumn(CONSTANTS.classes.estPrice, row, priceIdx);
     };
   }
 }
@@ -258,8 +263,8 @@ Enhancer.enhanceMarketHistoryTable = function enhanceMarketHistoryTable(table){
       let row = rows[i];
       let isUsdtMarket = Enhancer.getMarketType() === 'usdt';
       if(i===0) {
-        updateHeader("mkt-history-bid-usd-val", row, 2, 'BID/ASK (Est. ' + (isUsdtMarket?'BTC':'USD') + ')');
-        updateHeader("mkt-history-total-usd-val", row, 5, 'TOTAL COST (Est. ' + (isUsdtMarket?'BTC':'USD') + ')');
+        updateHeader(CONSTANTS.classes.mktHistoryBidAskUsdVal, row, 2, 'BID/ASK (Est. ' + (isUsdtMarket?'BTC':'USD') + ')');
+        updateHeader(CONSTANTS.classes.mktHistoryTotalUsdVal, row, 5, 'TOTAL COST (Est. ' + (isUsdtMarket?'BTC':'USD') + ')');
         continue;
       }
       let alreadyInserted = getChildNodeWithClass(row, "mkt-hist-usd-price");
@@ -269,8 +274,8 @@ Enhancer.enhanceMarketHistoryTable = function enhanceMarketHistoryTable(table){
         priceIdx += 1;
         totalIdx += 1;
       }
-      updateColumn("mkt-hist-usd-price", row, priceIdx);
-      updateColumn("mkt-hist-usd-total", row, totalIdx);
+      updateColumn(CONSTANTS.classes.mktHistoryUsdPrice, row, priceIdx);
+      updateColumn(CONSTANTS.classes.nktHistoryUsdTotal, row, totalIdx);
     };
   }
 }

--- a/enhancer.js
+++ b/enhancer.js
@@ -5,6 +5,7 @@ const CONSTANTS = {
   tvChartURL: '//s3.tradingview.com/tv.js',
   btcEthTrexApiURL: 'https://bittrex.com/api/v1.1/public/getticker?market=BTC-ETH',
   btcPriceDomExpr: '[data-bind="text:navigation.displayBitcoinUsd"]',
+  loginNodeExpr: ".fa-sign-in",
   buyOrdersTableDomID: 'buyOrdersTable',
   sellOrdersTableDomID: 'sellOrdersTable',
   marketHistoryTableDomID: 'marketHistoryTable2',
@@ -194,7 +195,8 @@ Enhancer.enhanceMarketsTable = function enhanceMarketsTable(table){
       // Volume -> USD
       let columns = row.getElementsByTagName('td');
       let alreadyInserted = getChildNodeWithClass(row, CONSTANTS.classes.estUsdPrice);
-      updateColumn(CONSTANTS.classes.estUsdPrice, row, alreadyInserted ? 5 : 4, Enhancer.getMarketType(columns[0].innerText));
+      let priceColIdx = alreadyInserted ? 5 : 4;
+      updateColumn(CONSTANTS.classes.estUsdPrice, row, priceColIdx, Enhancer.getMarketType(columns[0].innerText));
     }
   }
 }
@@ -240,7 +242,10 @@ Enhancer.enhanceOrderTable = function enhanceOrderTable(type, table){
     let priceColIdx = type === 'buy' ? 4 : 1;
     let title = type === 'buy' ? 'BID' : 'ASK';
     let isUsdtMarket = Enhancer.getMarketType() === 'usdt';
-    // TODO: adjust if signed in or not
+    let isLoggedIn = document.querySelectorAll(CONSTANTS.loginNodeExpr).length === 0;
+    if(!isLoggedIn){
+      priceColIdx -=1;
+    }
     for(let i=0; i<rows.length; i++){
       let row = rows[i];
       if(i===0) {
@@ -267,7 +272,7 @@ Enhancer.enhanceMarketHistoryTable = function enhanceMarketHistoryTable(table){
         updateHeader(CONSTANTS.classes.mktHistoryTotalUsdVal, row, 5, 'TOTAL COST (Est. ' + (isUsdtMarket?'BTC':'USD') + ')');
         continue;
       }
-      let alreadyInserted = getChildNodeWithClass(row, "mkt-hist-usd-price");
+      let alreadyInserted = getChildNodeWithClass(row, CONSTANTS.classes.mktHistoryUsdPrice);
       let priceIdx = 2;
       let totalIdx = 5;
       if(alreadyInserted){
@@ -275,7 +280,7 @@ Enhancer.enhanceMarketHistoryTable = function enhanceMarketHistoryTable(table){
         totalIdx += 1;
       }
       updateColumn(CONSTANTS.classes.mktHistoryUsdPrice, row, priceIdx);
-      updateColumn(CONSTANTS.classes.nktHistoryUsdTotal, row, totalIdx);
+      updateColumn(CONSTANTS.classes.mktHistoryUsdTotal, row, totalIdx);
     };
   }
 }

--- a/manifest.json
+++ b/manifest.json
@@ -26,6 +26,7 @@
       "matches": [
         "https://bittrex.com/Market/Index?MarketName=BTC-*",
         "https://bittrex.com/Market/Index?MarketName=ETH-*",
+        "https://bittrex.com/Market/Index?MarketName=USDT-*",
         "https://bittrex.com/Balance",
         "https://bittrex.com/home/markets*",
         "https://bittrex.com/Home/Markets*",


### PR DESCRIPTION
- Refactor price inclusion mechanism - use td's and add columns to tables as opposed to inline
- Enhancer will load on /Index?MarketName=USDT-* pages
- Use `updateColumn` and `updateHeader` universally (incl. order book)
- UpdateColumn will now insert a new <td> element into the <tr> and re-use it
- Refactor headers to incl. "USD" or "BTC" as appropriate
- Market History Table doesn't get updated for USDT-BTC, otherwise does

Closes #13 