### PR TITLE
Enhancement/order history page

### DIFF
--- a/enhanced-styles.css
+++ b/enhanced-styles.css
@@ -10,7 +10,6 @@
     border-radius: 0px !important;
 }
 .table td.est-usd-price,
-.table td.est-btc-price,
 .table td.est-usd-value,
 .table td.mkt-hist-usd-price,
 .table td.mkt-hist-usd-total,
@@ -21,9 +20,12 @@
 #est-price-ETH,
 #est-btc-price,
 #est-usd-value,
+#est-usd-price,
 #est-price-buy,
 #est-price-sell,
 #mkt-history-bid-usd-val,
-#mkt-history-total-usd-val { 
+#mkt-history-total-usd-val,
+.table td.est-btc-price
+{ 
     text-align:center; 
 }

--- a/enhancer.js
+++ b/enhancer.js
@@ -237,16 +237,28 @@ Enhancer.enhanceHistoryTable = function enhanceHistoryOpenTable(type, table){
   if(rows && rows.length > 1){
     for(let i=0; i<rows.length; i++){
       let row = rows[i];
+      let priceIdx = type === 'closed' ? 7 : 4;
+      let totalIdx = type === 'closed' ? 9 : 9;
       if(i===0) {
-        updateHeader(CONSTANTS.classes.estUsdValue+"-"+type, row, 9, (type === 'closed' ? 'Hyp.' : 'Est.') +' USD Value');
+        updateHeader(CONSTANTS.classes.estUsdPrice+"-"+type, row, priceIdx, (type === 'closed' ? 'Hyp.' : 'Est.') + ' USD Price');
+        updateHeader(CONSTANTS.classes.estUsdValue+"-"+type, row, totalIdx, (type === 'closed' ? 'Hyp.' : 'Est.') +' USD Value');
         continue;
       }
       // BTC Value + USD
       let alreadyInserted = getChildNodeWithClass(row, CONSTANTS.classes.estUsdValue);
-      let priceIdx = 8;
+      if(alreadyInserted){
+        priceIdx += 1;
+        totalIdx += 1;
+      }
       let columns = row.getElementsByTagName('td');
-      let estUsdValue = parseFloat(columns[priceIdx].innerText) * Enhancer.prices.btcUsd;
-      updateColumn(CONSTANTS.classes.estUsdValue, row, 9, 'fiat', '$'+estUsdValue.format(2));
+      let pIdx = priceIdx + (type === 'closed' && !alreadyInserted ? -1 : 0);
+      let vIdx = totalIdx + (type === 'closed' && !alreadyInserted ? -1 : 0);
+      let mIdx = 2;
+      let isEthOrder = columns[mIdx].innerText.toLowerCase().startsWith('eth');
+      let estUsdPrice = parseFloat(columns[pIdx].innerText) * Enhancer.getCurrentPrice(isEthOrder?'eth':'btc');
+      let estUsdValue = parseFloat(columns[vIdx].innerText) * Enhancer.getCurrentPrice(isEthOrder?'eth':'btc');
+      updateColumn(CONSTANTS.classes.estUsdPrice, row, priceIdx, 'fiat', '$'+estUsdPrice.format(2));
+      updateColumn(CONSTANTS.classes.estUsdValue, row, totalIdx, 'fiat', '$'+estUsdValue.format(2));
     }
   }
 };

--- a/manifest.json
+++ b/manifest.json
@@ -28,6 +28,7 @@
         "https://bittrex.com/Market/Index?MarketName=ETH-*",
         "https://bittrex.com/Market/Index?MarketName=USDT-*",
         "https://bittrex.com/Balance",
+        "https://bittrex.com/History",
         "https://bittrex.com/home/markets*",
         "https://bittrex.com/Home/Markets*",
         "https://bittrex.com/"


### PR DESCRIPTION
* Add support for /History page
* For open orders..
   * Shows Est. USD Price for ETH- and BTC- orders
   * Shows Est. USD Total for ETH- and BTC- orders
* For completed orders...
   * Shows Hyp. USD Price for ETH- and BTC- orders (given current prices)
   * Shows Hyp. USD Total for ETH- and BTC- orders (given current prices)

Closes #23