### PR TITLE
Support plugin for *.bittrex.com (www. inclusive)

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -24,14 +24,14 @@
   "content_scripts": [
     {
       "matches": [
-        "https://bittrex.com/Market/Index?MarketName=BTC-*",
-        "https://bittrex.com/Market/Index?MarketName=ETH-*",
-        "https://bittrex.com/Market/Index?MarketName=USDT-*",
-        "https://bittrex.com/Balance",
-        "https://bittrex.com/History",
-        "https://bittrex.com/home/markets*",
-        "https://bittrex.com/Home/Markets*",
-        "https://bittrex.com/"
+        "https://*.bittrex.com/Market/Index?MarketName=BTC-*",
+        "https://*.bittrex.com/Market/Index?MarketName=ETH-*",
+        "https://*.bittrex.com/Market/Index?MarketName=USDT-*",
+        "https://*.bittrex.com/Balance",
+        "https://*.bittrex.com/History",
+        "https://*.bittrex.com/home/markets*",
+        "https://*.bittrex.com/Home/Markets*",
+        "https://*.bittrex.com/"
       ],
       "js": ["enhancer.js"],
       "css": ["enhanced-styles.css"]


### PR DESCRIPTION
Previously was limited to https://bittrex.com, now supports *.bittrex.com.